### PR TITLE
[Tests] helpers.php tests in HelpersTest

### DIFF
--- a/src/MultiLang/Middleware/MultiLang.php
+++ b/src/MultiLang/Middleware/MultiLang.php
@@ -65,7 +65,7 @@ class MultiLang
         $url = $this->multilang->getRedirectUrl($request);
 
         if ($url !== null) {
-            if ($request->wantsJson()) {
+            if ($request->expectsJson()) {
                 return response('Not found', 404);
             } else {
                 return $this->redirector->to($url);

--- a/src/MultiLang/MultiLang.php
+++ b/src/MultiLang/MultiLang.php
@@ -183,7 +183,7 @@ class MultiLang
             return $texts;
         }
 
-        if ($this->repository->existsInCache($lang)) {
+        if ($this->repository->existsInCache($lang, $scope)) {
             $texts = $this->repository->loadFromCache($lang, $scope);
         } else {
             $texts = $this->repository->loadFromDatabase($lang, $scope);

--- a/tests/Unit/HelpersTest.php
+++ b/tests/Unit/HelpersTest.php
@@ -2,9 +2,14 @@
 
 namespace Tests\Unit;
 
+use Illuminate\Contracts\Routing\UrlGenerator;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Routing\Redirector;
+use InvalidArgumentException;
+use Longman\LaravelMultiLang\MultiLang;
+
 /**
  * This is the service provider test class.
- *
  */
 class HelpersTest extends AbstractTestCase
 {
@@ -24,8 +29,8 @@ class HelpersTest extends AbstractTestCase
         $multilang = app('multilang');
 
         $texts = [
-            'text1'    => 'value1',
-            'text2'    => 'value2',
+            'text1' => 'value1',
+            'text2' => 'value2',
             'te.x-t/3' => 'value3',
         ];
 
@@ -39,11 +44,12 @@ class HelpersTest extends AbstractTestCase
      */
     public function lang_url_should_return_valid_url()
     {
+        /** @var MultiLang $multilang */
         $multilang = app('multilang');
 
         $texts = [
-            'text1'    => 'value1',
-            'text2'    => 'value2',
+            'text1' => 'value1',
+            'text2' => 'value2',
             'te.x-t/3' => 'value3',
         ];
 
@@ -52,4 +58,41 @@ class HelpersTest extends AbstractTestCase
         $this->assertEquals('http://localhost/ka/users/list', lang_url('users/list'));
     }
 
+    /**
+     * @test
+     */
+    public function lang_url_should_return_url_generator_if_path_is_null()
+    {
+        $this->assertInstanceOf(UrlGenerator::class, lang_url());
+    }
+
+    /** @test */
+    public function lang_redirect_should_return_redirector_instance_if_path_is_null()
+    {
+        $this->assertInstanceOf(Redirector::class, lang_redirect());
+    }
+
+    /** @test */
+    public function lang_redirect_should_return_redirect_response()
+    {
+        /** @var MultiLang $multilang */
+        $multilang = app('multilang');
+        $multilang->setLocale('ka');
+
+        $redirect = lang_redirect('path', 302, ['X-header' => 'value']);
+
+        $this->assertInstanceOf(RedirectResponse::class, $redirect);
+        $this->assertEquals('http://localhost/ka/path', $redirect->getTargetUrl());
+        $this->assertEquals($redirect->headers->get('X-header'), 'value');
+        $this->assertEquals($redirect->getStatusCode(), 302);
+    }
+
+    /**
+     * @test
+     * @expectedException InvalidArgumentException
+     */
+    public function lang_route_should_throw_exception_if_route_is_not_defined()
+    {
+        lang_route('missing-route');
+    }
 }

--- a/tests/Unit/MultiLangTest.php
+++ b/tests/Unit/MultiLangTest.php
@@ -2,6 +2,9 @@
 
 namespace Tests\Unit;
 
+use Illuminate\Http\Request;
+use Longman\LaravelMultiLang\MultiLang;
+
 class MultiLangTest extends AbstractTestCase
 {
 
@@ -47,14 +50,14 @@ class MultiLangTest extends AbstractTestCase
         $config = [
             'locales' => [
                 'en' => [
-                    'name'        => 'English',
+                    'name' => 'English',
                     'native_name' => 'English',
-                    'default'     => true,
+                    'default' => true,
                 ],
                 'ka' => [
-                    'name'        => 'Georgian',
+                    'name' => 'Georgian',
                     'native_name' => 'ქართული',
-                    'default'     => false,
+                    'default' => false,
                 ],
             ],
         ];
@@ -85,8 +88,8 @@ class MultiLangTest extends AbstractTestCase
     {
         $multilang = $this->getMultilang('testing');
         $texts = [
-            'text1'    => 'value1',
-            'text2'    => 'value2',
+            'text1' => 'value1',
+            'text2' => 'value2',
             'te.x-t/3' => 'value3',
         ];
 
@@ -104,8 +107,8 @@ class MultiLangTest extends AbstractTestCase
         $multilang->setLocale('ka');
 
         $multilang->setTexts([
-            'text1'    => 'value1',
-            'text2'    => 'value2',
+            'text1' => 'value1',
+            'text2' => 'value2',
             'te.x-t/3' => 'value3',
         ]);
 
@@ -133,8 +136,8 @@ class MultiLangTest extends AbstractTestCase
         $multilang->setLocale('ka');
 
         $multilang->setTexts([
-            'text1'    => 'value1',
-            'text2'    => 'value2',
+            'text1' => 'value1',
+            'text2' => 'value2',
             'te.x-t/3' => 'value3',
         ]);
 
@@ -150,8 +153,8 @@ class MultiLangTest extends AbstractTestCase
         $multilang->setLocale('ka');
 
         $texts = [
-            'text1'                   => 'value1',
-            'text2'                   => 'value2',
+            'text1' => 'value1',
+            'text2' => 'value2',
             'te.x-t/3 dsasad sadadas' => 'value3',
         ];
 
@@ -271,14 +274,14 @@ class MultiLangTest extends AbstractTestCase
         $config = [
             'locales' => [
                 'en' => [
-                    'name'        => 'English',
+                    'name' => 'English',
                     'native_name' => 'English',
-                    'default'     => true,
+                    'default' => true,
                 ],
                 'ka' => [
-                    'name'        => 'Georgian',
+                    'name' => 'Georgian',
                     'native_name' => 'ქართული',
-                    'default'     => false,
+                    'default' => false,
                 ],
             ],
         ];
@@ -403,5 +406,44 @@ class MultiLangTest extends AbstractTestCase
         $this->assertTrue($multilang->saveTexts());
 
         $this->assertTrue($multilang->saveTexts());
+    }
+
+    /** @test */
+    public function scope_setter_and_getter()
+    {
+        $instance = $this->getMultilang();
+        $instance->setScope('test-scope');
+
+        $this->assertInstanceOf(MultiLang::class, $instance);
+        $this->assertEquals('test-scope', $instance->getScope());
+    }
+
+    /** @test */
+    public function load_texts_from_cache_repository()
+    {
+        $multilang = $this->getMultilang('production');
+        $multilang->setLocale('ka');
+        $texts = $multilang->getRepository()->loadFromDatabase('ka', 'global');
+        $multilang->getRepository()->storeInCache('ka', $texts, 'global');
+
+        $this->assertTrue($multilang->getRepository()->existsInCache('ka', 'global'));
+        $cacheTexts = $multilang->loadTexts('ka', 'global');
+        $this->assertCount(count($texts), $cacheTexts);
+    }
+
+    /** @test */
+    public function detect_locale_should_return_default_locale_if_non_set()
+    {
+        $multilang = $this->getMultilang();
+        $fallback = $multilang->detectLocale(new Request());
+
+        $this->assertEquals('en', $fallback);
+    }
+
+    /** @test */
+    public function get_all_texts_should_return_all_from_database()
+    {
+        $multilang = $this->getMultilang();
+        $this->assertCount(11, $multilang->getAllTexts('ka', 'global')['ka']);
     }
 }


### PR DESCRIPTION
lang_route can't be tested otherway since you need predefined route.
If you have any suggestion how to stub this, please let me know.